### PR TITLE
Update UrlMappingsSpec.groovy

### DIFF
--- a/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy
+++ b/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy
@@ -124,4 +124,20 @@ class UrlMappingsSpec extends Specification implements UrlMappingsUnitTest<UrlMa
         noExceptionThrown()
     }
     // end::combined[]
+    
+    // tag::httpmethods[]
+    void "test url mappings for different http methods"() {
+        when: "the http method is GET, /api/route should map to ApiController.index()"
+        request.method = "GET"
+        assertUrlMapping("/api/route", controller: "api", action: "index", method: "GET")
+        then: "expect no exception"
+        noExceptionThrown()
+        
+        when: "the http method is POST, /api/route should map to ApiController.save()"
+        request.method = "POST"
+        assertUrlMapping("/api/route", controller: "api", action: "save", method: "POST")
+        then: "expect no exception"
+        noExceptionThrown()
+    }
+    // end::httpmethods[]
 }


### PR DESCRIPTION
Added test to demonstrate using different http methods. The existing documentation doesn't make it clear how this can be achieved, particularly the bit about specifying the request.method before calling assertUrlMapping. If this pull request is successful, I can incorporate the new test into the main documentation on testing url mappings (https://testing.grails.org/latest/guide/index.html#unitTestingUrlMappings)