### PR TITLE
Added documentation for unit testing url mappings using different HTTP methods

### DIFF
--- a/apps/demo33/grails-app/controllers/demo/UrlMappings.groovy
+++ b/apps/demo33/grails-app/controllers/demo/UrlMappings.groovy
@@ -3,6 +3,9 @@ package demo
 class UrlMappings {
 
     static mappings = {
+        "/api/render" (method: "GET", controller: "test", action: "renderText")
+        "/api/render" (method: "POST", controller: "test", action: "renderView")
+        
         "/$controller/$action?/$id?(.$format)?"{
             constraints {
                 // apply constraints here

--- a/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy
+++ b/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy
@@ -124,4 +124,20 @@ class UrlMappingsSpec extends Specification implements UrlMappingsUnitTest<UrlMa
         noExceptionThrown()
     }
     // end::combined[]
+    
+    // tag::httpmethods[]
+    void "test url mappings for different http methods"() {
+        when: "the http method is GET, /api/render should map to TestController.renderText()"
+        request.method = "GET"
+        assertUrlMapping("/api/render", controller: "test", action: "renderText", method: "GET")
+        then: "expect no exception"
+        noExceptionThrown()
+        
+        when: "the http method is POST, /api/render should map to TestController.renderView()"
+        request.method = "POST"
+        assertUrlMapping("/api/render", controller: "test", action: "renderView", method: "POST")
+        then: "expect no exception"
+        noExceptionThrown()
+    }
+    // end::httpmethods[]
 }

--- a/src/main/docs/guide/unitTesting/unitTestingUrlMappings.adoc
+++ b/src/main/docs/guide/unitTesting/unitTestingUrlMappings.adoc
@@ -53,6 +53,15 @@ include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tag
 
 NOTE: When calling `verifyUrlMapping`, then reverse mapping will only be checked if a controller is supplied and the first parameter is not an HTTP status code.
 
+=== Using HTTP Methods
+
+In order to test a URL mapping using different HTTP methods (GET, POST, PUT etc.) it is necessary to specify the HTTP method in the request and also in the `assert` or `verify` method call.
+
+[source,groovy]
+----
+include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpmethods,indent=0]
+----
+
 === Other Helpful Methods
 
 ==== Controller Check


### PR DESCRIPTION
It isn't obvious how to unit test url mappings using different HTTP methods without documentation and/or an example