### PR TITLE
Forward/combined url mappings using http methods

### DIFF
--- a/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy
+++ b/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy
@@ -125,8 +125,8 @@ class UrlMappingsSpec extends Specification implements UrlMappingsUnitTest<UrlMa
     }
     // end::combined[]
 
-    // tag::httpMethods[]
-    void "test http methods"() {
+    // tag::httpMethodsReverse[]
+    void "test reverse mappings with http methods"() {
         expect:
         !verifyReverseUrlMapping('/foo', controller: 'test', action: 'fooGet')
         verifyReverseUrlMapping('/foo', controller: 'test', action: 'fooGet', method: 'GET')
@@ -141,6 +141,42 @@ class UrlMappingsSpec extends Specification implements UrlMappingsUnitTest<UrlMa
         then:
         noExceptionThrown()
     }
-    // end::httpMethods[]
+    // end::httpMethodsReverse[]
+
+    // tag::httpMethodsForward[]
+    void "test forward mappings with http methods"() {
+        when: "the http method is GET, /foo should map to TestController.fooGet()"
+        request.method = "GET"
+        assertForwardUrlMapping('/foo', controller: 'test', action: 'fooGet')
+
+        then:
+        noExceptionThrown()
+
+        when: "the http method is POST, /foo should map to TestController.fooPost()"
+        request.method = "POST"
+        assertForwardUrlMapping('/foo', controller: 'test', action: 'fooPost')
+
+        then:
+        noExceptionThrown()
+    }
+    // end::httpMethodsForward[]
+
+    // tag::httpMethodsCombined[]
+    void "test forward and reverse mappings with http methods"() {
+        when: "the http method is GET, /foo should map to TestController.fooGet()"
+        request.method = "GET"
+        assertUrlMapping('/foo', controller: 'test', action: 'fooGet', method: 'GET')
+
+        then:
+        noExceptionThrown()
+
+        when: "the http method is POST, /foo should map to TestController.fooPost()"
+        request.method = "POST"
+        assertUrlMapping('/foo', controller: 'test', action: 'fooPost', method: 'POST')
+
+        then:
+        noExceptionThrown()
+    }
+    // end::httpMethodsCombined[]
 }
 

--- a/src/main/docs/guide/unitTesting/unitTestingUrlMappings.adoc
+++ b/src/main/docs/guide/unitTesting/unitTestingUrlMappings.adoc
@@ -55,11 +55,25 @@ NOTE: When calling `verifyUrlMapping`, then reverse mapping will only be checked
 
 === HTTP Methods
 
-When testing HTTP methods on URL it is necessary to also define the HTTP method in the test.
+When testing HTTP methods on reverse URL mapping it is necessary to specify the HTTP method in the test
 
 [source,groovy]
 ----
-include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpMethods,indent=0]
+include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpMethodsReverse,indent=0]
+----
+
+When testing HTTP methods on forward URL mapping it is necessary to specify the HTTP method in the request
+
+[source,groovy]
+----
+include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpMethodsForward,indent=0]
+----
+
+When testing HTTP methods on both forward and reverse URL mapping combined it is necessary to specify the HTTP method in both the request and in the test
+
+[source,groovy]
+----
+include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpMethodsCombined,indent=0]
 ----
 
 === Other Helpful Methods

--- a/src/main/docs/guide/unitTesting/unitTestingUrlMappings.adoc
+++ b/src/main/docs/guide/unitTesting/unitTestingUrlMappings.adoc
@@ -55,21 +55,21 @@ NOTE: When calling `verifyUrlMapping`, then reverse mapping will only be checked
 
 === HTTP Methods
 
-When testing HTTP methods on reverse URL mapping it is necessary to specify the HTTP method in the test
+When testing HTTP methods on reverse URL mapping it is necessary to specify the HTTP method in the test.
 
 [source,groovy]
 ----
 include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpMethodsReverse,indent=0]
 ----
 
-When testing HTTP methods on forward URL mapping it is necessary to specify the HTTP method in the request
+When testing HTTP methods on forward URL mapping it is necessary to specify the HTTP method in the request.
 
 [source,groovy]
 ----
 include::{sourcedir}/apps/demo33/src/test/groovy/demo/UrlMappingsSpec.groovy[tags=httpMethodsForward,indent=0]
 ----
 
-When testing HTTP methods on both forward and reverse URL mapping combined it is necessary to specify the HTTP method in both the request and in the test
+When testing HTTP methods on both forward and reverse URL mapping combined it is necessary to specify the HTTP method in both the request and in the test.
 
 [source,groovy]
 ----


### PR DESCRIPTION
The current documentation describes how to test reverse url mappings using different HTTP methods, but it isn't obvious how to unit test **forward** and **combined** url mappings using different HTTP methods without documentation and/or an example. When you're using assertForwardUrlMapping or assertUrlMapping, you have to explicitly set the request.method first. This PR documents this.