### PR TITLE
Fix issue with unit test on domain with multiple dataSource. 

### DIFF
--- a/apps/demo32/grails-app/conf/application.yml
+++ b/apps/demo32/grails-app/conf/application.yml
@@ -102,7 +102,14 @@ dataSource:
     driverClassName: org.h2.Driver
     username: sa
     password:
-
+dataSources:
+  secondDb:
+      pooled: true
+      jmxExport: true
+      driverClassName: org.h2.Driver
+      username: sa
+      password:
+      dialect: org.hibernate.dialect.H2Dialect
 environments:
     development:
         dataSource:

--- a/apps/demo32/grails-app/domain/demo/Car.groovy
+++ b/apps/demo32/grails-app/domain/demo/Car.groovy
@@ -1,0 +1,13 @@
+package demo
+
+class Car {
+    String name
+    String color
+
+    static constraints = {
+    }
+
+    static mapping = {
+        datasource 'secondDb'
+    }
+}

--- a/apps/demo32/src/test/groovy/demo/CarSpec.groovy
+++ b/apps/demo32/src/test/groovy/demo/CarSpec.groovy
@@ -1,0 +1,22 @@
+package demo
+
+import grails.testing.gorm.DomainUnitTest
+import spock.lang.Specification
+
+class CarSpec extends Specification implements DomainUnitTest<Car> {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test basic persistence mocking"() {
+        setup:
+        new Car(name: 'grails car', color: 'green').save()
+        new Car(name: 'gorm car').save()
+
+        expect:
+        Car.count() == 1
+    }
+}

--- a/apps/demo33/grails-app/conf/application.yml
+++ b/apps/demo33/grails-app/conf/application.yml
@@ -100,7 +100,14 @@ dataSource:
     driverClassName: org.h2.Driver
     username: sa
     password:
-
+dataSources:
+  secondDb:
+      pooled: true
+      jmxExport: true
+      driverClassName: org.h2.Driver
+      username: sa
+      password:
+      dialect: org.hibernate.dialect.H2Dialect
 environments:
     development:
         dataSource:

--- a/apps/demo33/grails-app/domain/demo/Car.groovy
+++ b/apps/demo33/grails-app/domain/demo/Car.groovy
@@ -1,0 +1,13 @@
+package demo
+
+class Car {
+    String name
+    String color
+
+    static constraints = {
+    }
+
+    static mapping = {
+        datasource 'secondDb'
+    }
+}

--- a/apps/demo33/grails-app/services/demo/CarService.groovy
+++ b/apps/demo33/grails-app/services/demo/CarService.groovy
@@ -1,0 +1,10 @@
+package demo
+
+import grails.gorm.services.Service
+
+@Service(Car)
+class CarService{
+    List<Car> list(){
+        Car.list()
+    }
+}

--- a/apps/demo33/src/test/groovy/demo/CarServiceSpec.groovy
+++ b/apps/demo33/src/test/groovy/demo/CarServiceSpec.groovy
@@ -1,0 +1,22 @@
+package demo
+
+import grails.testing.gorm.DataTest
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+
+class CarServiceSpec extends Specification implements ServiceUnitTest<CarService>, DataTest{
+
+    void setupSpec() {
+        mockDomain Car
+    }
+
+    void setup(){
+        new Car(name: 'grails car', color: 'green').save(flush:true)
+        new Car(name: 'gorm car').save(flush:true)
+    }
+
+    void 'test one'() {
+        expect:
+        service.list().size() == 1
+    }
+}

--- a/apps/demo33/src/test/groovy/demo/CarSpec.groovy
+++ b/apps/demo33/src/test/groovy/demo/CarSpec.groovy
@@ -13,8 +13,8 @@ class CarSpec extends Specification implements DomainUnitTest<Car> {
 
     void "test basic persistence mocking"() {
         setup:
-        new Car(name: 'grails', color: 'green').save()
-        new Car(name: 'gorm').save()
+        new Car(name: 'grails car', color: 'green').save()
+        new Car(name: 'gorm car').save()
 
         expect:
         Car.count() == 1

--- a/apps/demo33/src/test/groovy/demo/CarSpec.groovy
+++ b/apps/demo33/src/test/groovy/demo/CarSpec.groovy
@@ -1,0 +1,22 @@
+package demo
+
+import grails.testing.gorm.DomainUnitTest
+import spock.lang.Specification
+
+class CarSpec extends Specification implements DomainUnitTest<Car> {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test basic persistence mocking"() {
+        setup:
+        new Car(name: 'grails', color: 'green').save()
+        new Car(name: 'gorm').save()
+
+        expect:
+        Car.count() == 1
+    }
+}

--- a/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
+++ b/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
@@ -56,9 +56,7 @@ class DataTestSetupSpecInterceptor implements IMethodInterceptor {
                     Class.forName(source)
                 }
             })
-            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config.dataSources.collect {
-                it.key
-            }, testInstance.domainClassesToMock?: [] as Class<?>[]
+            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config.dataSources.keySet(), testInstance.domainClassesToMock?: [] as Class<?>[]
 
             if (IS_OLD_SETUP) {
                 "${BEAN_NAME}"(constraintsEvaluator) {

--- a/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
+++ b/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
@@ -58,7 +58,7 @@ class DataTestSetupSpecInterceptor implements IMethodInterceptor {
             })
             grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config.dataSources.collect {
                 it.key
-            }, testInstance.domainClassesToMock?: []
+            }, testInstance.domainClassesToMock?: [] as Class<?>[]
 
             if (IS_OLD_SETUP) {
                 "${BEAN_NAME}"(constraintsEvaluator) {

--- a/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
+++ b/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
@@ -56,10 +56,9 @@ class DataTestSetupSpecInterceptor implements IMethodInterceptor {
                     Class.forName(source)
                 }
             })
-
             grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config.dataSources.collect {
                 it.key
-            }, getClass().getPackage()
+            }, testInstance.domainClassesToMock?: []
 
             if (IS_OLD_SETUP) {
                 "${BEAN_NAME}"(constraintsEvaluator) {

--- a/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
+++ b/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
@@ -8,6 +8,7 @@ import org.grails.datastore.gorm.validation.constraints.UniqueConstraintFactory
 import org.grails.datastore.gorm.validation.constraints.builtin.UniqueConstraint
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
+import org.grails.datastore.mapping.core.DatastoreUtils
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.reflect.ClassUtils
 import org.grails.datastore.mapping.simple.SimpleMapDatastore
@@ -56,7 +57,9 @@ class DataTestSetupSpecInterceptor implements IMethodInterceptor {
                 }
             })
 
-            grailsDatastore SimpleMapDatastore, application.mainContext
+            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config.dataSources.collect {
+                it.key
+            }, getClass().getPackage()
 
             if (IS_OLD_SETUP) {
                 "${BEAN_NAME}"(constraintsEvaluator) {


### PR DESCRIPTION
As mentionned in https://github.com/grails/grails-testing-support/issues/21, and https://github.com/grails/grails-core/issues/10888
we are unable to test or use domain in unit test. 
I create simple tests case to reproduce this issue (CarSpec, CarServiceSpec), with new domain (Car) in second datasource.
 
The proposed solution works well and all tests pass successfully.