### PR TITLE
#41 Fixed BUG! exception in phase 'semantic analysis'

### DIFF
--- a/grails-web-testing-support/src/main/groovy/grails/testing/web/taglib/TagLibUnitTest.groovy
+++ b/grails-web-testing-support/src/main/groovy/grails/testing/web/taglib/TagLibUnitTest.groovy
@@ -41,12 +41,12 @@ trait TagLibUnitTest<T> implements ParameterizedGrailsUnitTest<T>, GrailsWebUnit
      */
     String applyTemplate(String contents, Map model = [:]) {
         ensureTaglibHasBeenMocked()
-        GrailsWebUnitTest.super.applyTemplate(contents, model)
+        super.applyTemplate(contents, model)
     }
 
     void applyTemplate(StringWriter sw, String template, Map params = [:]) {
         ensureTaglibHasBeenMocked()
-        GrailsWebUnitTest.super.applyTemplate(sw, template, params)
+        super.applyTemplate(sw, template, params)
     }
 
     /**


### PR DESCRIPTION
It is happening because of `GrailsWebUnitTest.super.applyTemplate`. Either we need to add check if GrailsWebUnitTest is resolved or we could simply call super.applyTemplate from parent traits.