### PR TITLE
Added support for retrieval of render template model.

### DIFF
--- a/grails-web-testing-support/src/main/groovy/grails/testing/web/controllers/ControllerUnitTest.groovy
+++ b/grails-web-testing-support/src/main/groovy/grails/testing/web/controllers/ControllerUnitTest.groovy
@@ -51,7 +51,11 @@ trait ControllerUnitTest<T> implements ParameterizedGrailsUnitTest<T>, GrailsWeb
      */
     @CompileStatic(TypeCheckingMode.SKIP)
     Map getModel() {
-        request.getAttribute(GrailsApplicationAttributes.CONTROLLER)?.modelAndView?.model ?: [:]
+        Map model = request.getAttribute(GrailsApplicationAttributes.CONTROLLER)?.modelAndView?.model
+        if (model == null) {
+            model = request.getAttribute(GrailsApplicationAttributes.TEMPLATE_MODEL)
+        }
+        return model ?: [:]
     }
 
     /**


### PR DESCRIPTION
Expanded `ControllerUnitTest.getModel()` in-order to encapsulate retrieval of `model` regardless of using `template` or `view` during `render`.