### PR TITLE
Fixes issue grails/grails-core#11453 when PromiseFactory is not present

### DIFF
--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsUnitTest.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsUnitTest.groovy
@@ -32,7 +32,6 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.MessageSource
 import org.springframework.util.ClassUtils
 
-import java.lang.reflect.Field
 import java.lang.reflect.Method
 
 @CompileStatic
@@ -164,12 +163,7 @@ trait GrailsUnitTest {
     private void cleanupPromiseFactory() {
         ClassLoader classLoader = getClass().classLoader
         if (ClassUtils.isPresent("grails.async.Promises", classLoader)) {
-            final String className = "grails.async.Promises"
-            final Field field = ClassUtils.forName(className, classLoader)
-                    .getDeclaredField("promiseFactory")
-            field.setAccessible(true)
-            final Object oldValue = field.get(Class.forName(className))
-            field.set(oldValue, null)
+            grails.async.Promises.promiseFactory = null
         }
     }
 }


### PR DESCRIPTION
For Grails non-web plugin project, we normally exclude the `async` plugin. However, any test extending GrailsUnitTest fails to compile because of the class `grails.async.Promises` do not exist. So, now we are using reflection to set the `promiseFactory` to `null` only if the class is present.

Fixes grails/grails-core#11453