### PR TITLE
Databinding improvements

### DIFF
--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
@@ -10,6 +10,8 @@ import grails.spring.BeanBuilder
 import grails.util.Holders
 import grails.util.Metadata
 import groovy.transform.CompileDynamic
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.spring.context.factory.MicronautBeanFactoryConfiguration
 import org.grails.plugins.IncludingPluginFilter
 import org.grails.spring.context.support.GrailsPlaceholderConfigurer
 import org.grails.spring.context.support.MapBasedSmartPropertyOverrideConfigurer
@@ -26,6 +28,10 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.AnnotationConfigUtils
 import org.springframework.context.support.ConversionServiceFactoryBean
 import org.springframework.context.support.StaticMessageSource
+import org.springframework.core.convert.ConversionService
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.Environment
+import org.springframework.core.env.PropertyResolver
 import org.springframework.util.ClassUtils
 
 /**
@@ -98,14 +104,14 @@ class GrailsApplicationBuilder {
         ConfigurableBeanFactory beanFactory = context.getBeanFactory()
         List beanExcludes = []
         beanExcludes.add(ConversionService.class)
-        beanExcludes.add(org.springframework.core.env.Environment.class)
+        beanExcludes.add(Environment.class)
         beanExcludes.add(PropertyResolver.class)
         beanExcludes.add(ConfigurableEnvironment.class)
         def objectMapper = io.micronaut.core.reflect.ClassUtils.forName("com.fasterxml.jackson.databind.ObjectMapper", context.getClassLoader()).orElse(null)
         if (objectMapper != null) {
             beanExcludes.add(objectMapper)
         }
-        def micronautContext = new io.micronaut.context.DefaultApplicationContext();
+        def micronautContext = new DefaultApplicationContext();
         micronautContext
                 .environment
                 .addPropertySource("grails-config", [(MicronautBeanFactoryConfiguration.PREFIX + ".bean-excludes"): (Object)beanExcludes])

--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
@@ -5,7 +5,6 @@ import grails.core.GrailsApplication
 import grails.core.GrailsApplicationLifeCycle
 import grails.core.support.proxy.DefaultProxyHandler
 import grails.plugins.GrailsPluginManager
-import grails.plugins.Plugin
 import grails.spring.BeanBuilder
 import grails.util.Holders
 import grails.util.Metadata
@@ -132,13 +131,6 @@ class GrailsApplicationBuilder {
     }
 
     void registerBeans(GrailsApplication grailsApplication) {
-
-        if (ClassUtils.isPresent("org.grails.plugins.databinding.DataBindingGrailsPlugin", GrailsApplicationBuilder.classLoader)) {
-            Plugin plugin = (Plugin)ClassUtils.forName("org.grails.plugins.databinding.DataBindingGrailsPlugin").newInstance()
-            plugin.grailsApplication = grailsApplication
-            plugin.applicationContext = grailsApplication.mainContext
-            defineBeans(grailsApplication, plugin.doWithSpring())
-        }
 
         defineBeans(grailsApplication) { ->
             conversionService(ConversionServiceFactoryBean)


### PR DESCRIPTION
Updated GrailsUnitTest trait to remove the use of deprecated `DataBindingGrailsPlugin` and use `DataBindingConfiguration` instead, and set Micronaut context as the parent application context.

This PR supports the ability to test DataBindingListerAdapter fixes in grails/grails-core#11462