### PR TITLE
Delete grailsApplication.mainContext.getBean("mimeTypesHolder") from …

### DIFF
--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
@@ -14,6 +14,7 @@ import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.core.order.Ordered
 import io.micronaut.spring.context.factory.MicronautBeanFactoryConfiguration
 import org.grails.plugins.IncludingPluginFilter
+import org.grails.plugins.web.mime.MimeTypesConfiguration
 import org.grails.spring.context.support.GrailsPlaceholderConfigurer
 import org.grails.spring.context.support.MapBasedSmartPropertyOverrideConfigurer
 import org.grails.transaction.TransactionManagerPostProcessor

--- a/grails-web-testing-support/src/main/groovy/org/grails/testing/spock/WebSetupSpecInterceptor.groovy
+++ b/grails-web-testing-support/src/main/groovy/org/grails/testing/spock/WebSetupSpecInterceptor.groovy
@@ -51,11 +51,6 @@ class WebSetupSpecInterceptor implements IMethodInterceptor {
         GrailsApplication grailsApplication = test.grailsApplication
         Map<String, String> groovyPages = test.views
 
-        //To register MimeTypes
-        if (grailsApplication.mainContext.parent) {
-            grailsApplication.mainContext.getBean("mimeTypesHolder")
-        }
-
         test.defineBeans(new ConvertersGrailsPlugin())
 
         def config = grailsApplication.config


### PR DESCRIPTION
…GrailsApplicationBuilder

Earlier, we call getBean("mimeTypesHolder") in order to initialize "mimeTypes" which is not required now because MimeType[] are properly initialized.