### PR TITLE
Use the pre-installed Chrome driver when running on GitHub

### DIFF
--- a/examples/demo33/build.gradle
+++ b/examples/demo33/build.gradle
@@ -11,8 +11,9 @@ buildscript {
 apply plugin:"com.github.erdi.webdriver-binaries"
 
 webdriverBinaries {
-    chromedriver {
-        versionRegexp = '.*'
+    if (!System.getenv().containsKey('CI')) {
+        chromedriver "$chromeDriverVersion"
+        geckodriver "$geckodriverVersion"
     }
 }
 
@@ -79,6 +80,13 @@ tasks.withType(Test) {
     systemProperty "geb.env", System.getProperty('geb.env')
     systemProperty "geb.build.reportsDir", reporting.file("geb/integrationTest")
     systemProperty "webdriver.chrome.driver", System.getProperty('webdriver.chrome.driver')
+    if (!System.getenv().containsKey('CI')) {
+        systemProperty 'webdriver.chrome.driver', System.getProperty('webdriver.chrome.driver')
+        systemProperty 'webdriver.gecko.driver', System.getProperty('webdriver.gecko.driver')
+    } else {
+        systemProperty 'webdriver.chrome.driver', "${System.getenv('CHROMEWEBDRIVER')}/chromedriver"
+        systemProperty 'webdriver.gecko.driver', "${System.getenv('GECKOWEBDRIVER')}/geckodriver"
+    }
 }
 
 

--- a/examples/demo33/gradle.properties
+++ b/examples/demo33/gradle.properties
@@ -3,6 +3,7 @@ gormVersion=7.1.0
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1024M
-chromeDriverVersion=95.0.4638.17
+geckodriverVersion=0.26.0
+chromeDriverVersion=96.0.4664.45
 micrometer.version=1.8.0
 micronaut.spring.version=4.0.1


### PR DESCRIPTION
The GitHub virtual environment already provides a Chrome and a matching Chrome driver.

For installed software see:
https://github.com/actions/virtual-environments/blob/ubuntu20/20220207.1/images/linux/Ubuntu2004-Readme.md#environment-variables-1

For available environment variables see:
https://docs.github.com/en/actions/learn-github-actions/environment-variables

Thanks to @darxriggs for suggesting the same in grails/grails-cache#123 plugin.