### PR TITLE
Remove old deprecated set-output command

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -17,10 +17,10 @@ jobs:
         id: check_release_drafter
         run: |
           has_release_drafter=$([ -f .github/release-drafter.yml ] && echo "true" || echo "false")
-          echo ::set-output name=has_release_drafter::${has_release_drafter}
+          echo "has_release_drafter=${has_release_drafter}" >> $GITHUB_OUTPUT
       - name: Extract branch name
         id: extract_branch
-        run: echo ::set-output name=value::${GITHUB_REF:11}
+        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       # If it has release drafter:
       - uses: release-drafter/release-drafter@v5
         if: steps.check_release_drafter.outputs.has_release_drafter == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:11}
+        run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         with:

--- a/.github/workflows/retry-release.yml
+++ b/.github/workflows/retry-release.yml
@@ -33,12 +33,12 @@ jobs:
         id: extract_branch
         run: |
           echo $TARGET_BRANCH
-          echo ::set-output name=value::${TARGET_BRANCH}
+          echo "value=${TARGET_BRANCH}" >> $GITHUB_OUTPUT
         env:
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${VERSION}
+        run: echo "release_version=${VERSION}" >> $GITHUB_OUTPUT
         env:
           VERSION: ${{ github.event.inputs.release }}
       - name: Run Assemble


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/