### PR TITLE
Use grails branch for github-pages-deploy-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
         uses: micronaut-projects/github-actions/export-gradle-properties@master
       - name: Publish to Github Pages
         if: steps.docs.outcome == 'success'
-        uses: micronaut-projects/github-pages-deploy-action@master
+        uses: micronaut-projects/github-pages-deploy-action@grails
         env:
-          BETA: ${{ contains(steps.release_version.outputs.release_version, 'M') || contains(steps.release_version.outputs.release_version, 'RC') }}
+          SKIP_SNAPSHOT: ${{ contains(steps.release_version.outputs.release_version, 'M') }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages
           FOLDER: build/docs


### PR DESCRIPTION
Use SKIP_SNAPSHOT env instead of BETA to skip publishing snapshot docs.