### PR TITLE
refactor(grails-gorm-testing-support): Replace deprecated usages of `NavigableMap`

### DIFF
--- a/examples/demo33/src/test/groovy/demo/ConfigServiceSpec.groovy
+++ b/examples/demo33/src/test/groovy/demo/ConfigServiceSpec.groovy
@@ -6,7 +6,7 @@ import spock.lang.Specification
 class ConfigServiceSpec extends Specification implements ServiceUnitTest<ConfigService> {
 
     Closure doWithConfig() {{ config ->
-        config.mc.allow.signup = true
+        config['mc.allow.signup'] = true
     }}
 
     def "singup is allowed if configuration parameter is set"() {

--- a/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
+++ b/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
@@ -43,7 +43,7 @@ class DataTestSetupSpecInterceptor implements IMethodInterceptor {
                     Class.forName(source)
                 }
             })
-            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config.dataSources.keySet(), testInstance.domainClassesToMock?: [] as Class<?>[]
+            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config?.dataSources?.keySet(), testInstance.domainClassesToMock?: [] as Class<?>[]
 
                 constraintRegistry(DefaultConstraintRegistry, ref("messageSource"))
                 grailsDomainClassMappingContext(grailsDatastore: "getMappingContext")

--- a/src/main/docs/guide/unitTesting.adoc
+++ b/src/main/docs/guide/unitTesting.adoc
@@ -83,7 +83,7 @@ To change configuration for the context of your test class, override the `doWith
 [source,groovy]
 ----
 Closure doWithConfig() {{ config ->
-    config.foo.bar = "x"
+    config['foo.bar'] = "x"
 }}
 ----
 


### PR DESCRIPTION
This PR replaces deprecated usages of `NavigableMap` so that it can be eventually removed and/or replaced by some other classes.

- Related issue: https://github.com/grails/grails-core/issues/13385

More specifically, `NavigableMap.NullSafeNavigator` can't be removed from `grails-core` at the moment, because there are some test suites that depend on [`DataTestSetupSpecInterceptor`](https://github.com/grails/grails-testing-support/pull/369/files#diff-b4c0d9ddc7e0988938dc8552c74184d543740991fd00d265c0f1e97cc1f5641aR46):
- [`grails-test-suite-persistence`](https://github.com/grails/grails-core/tree/7.0.x/grails-test-suite-persistence)
- [`grails-test-suite-uber`](https://github.com/grails/grails-core/tree/7.0.x/grails-test-suite-uber)
- [`grails-test-suite-web`](https://github.com/grails/grails-core/tree/7.0.x/grails-test-suite-web)

So first we need to release a new version of `grails-testing-support` that does not try to access the config in a deprecated way. Then we can continue exploring the possibility of removing `NavigableMap.NullSafeNavigator`.
