### PR TITLE
chore(release): enhance workflow configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 11
       - name: Set the current release version
         id: release_version
-        run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
+        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         with:
@@ -45,16 +45,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: testing-support-${{ steps.release_version.outputs.value }}.zip
-          path: build/distributions/testing-support-${{ steps.release_version.outputs.value }}.zip
-      - name: Upload artifacts to the Github release
-        if: success()
-        id: upload_artifact
-        uses: Roang-zero1/github-upload-release-artifacts-action@master
-        with:
-          args: build/distributions/testing-support-${{ steps.release_version.outputs.value }}.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          path: ./**/build/libs/*
       - name: Generate secring file
         env:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
     maven { url "https://repo.grails.org/grails/core" }
 }
 
+group = "org.grails"
 version project.projectVersion
 
 ext {


### PR DESCRIPTION
- Corrected key for GITHUB_OUTPUT in release workflow
- Updated path for Upload Distribution Step
- Removed unnecessary step for uploading artifacts to Github Release
- Defined group for rootProject to ensure nexus-publish plugin correctly matches staging repository via Gradle task findSonatypeStagingRepo.