### PR TITLE
refactor(grails-gorm-testing-support): Replace deprecated usages of `NavigableMap`

### DIFF
--- a/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
+++ b/grails-gorm-testing-support/src/main/groovy/org/grails/testing/gorm/spock/DataTestSetupSpecInterceptor.groovy
@@ -43,7 +43,7 @@ class DataTestSetupSpecInterceptor implements IMethodInterceptor {
                     Class.forName(source)
                 }
             })
-            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config?.dataSources?.keySet(), testInstance.domainClassesToMock?: [] as Class<?>[]
+            grailsDatastore SimpleMapDatastore, DatastoreUtils.createPropertyResolver(application.config), application.config?.dataSources?.keySet() ?: ([] as Set<String>), testInstance.domainClassesToMock?: [] as Class<?>[]
 
                 constraintRegistry(DefaultConstraintRegistry, ref("messageSource"))
                 grailsDomainClassMappingContext(grailsDatastore: "getMappingContext")


### PR DESCRIPTION
- This is a follow-up to: https://github.com/grails/grails-testing-support/pull/369

- Related issue: https://github.com/grails/grails-core/issues/13385
