### PR TITLE
Fix #157 - Support @Before* and @After* methods; Restore ordering similar to JUnit 4/Spock ordering

### DIFF
--- a/grails-testing-support/src/main/groovy/org/grails/testing/spock/TestingSupportExtension.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/spock/TestingSupportExtension.groovy
@@ -5,7 +5,9 @@ import grails.testing.spring.AutowiredTest
 import groovy.transform.CompileStatic
 import org.grails.testing.GrailsUnitTest
 import org.junit.After
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.spockframework.runtime.extension.AbstractGlobalExtension
 import org.spockframework.runtime.model.MethodInfo
@@ -32,7 +34,16 @@ class TestingSupportExtension extends AbstractGlobalExtension {
         }
         for (Method method : spec.getReflection().getDeclaredMethods()) {
             if (method.isAnnotationPresent(BeforeEach.class)) {
-                spec.addSetupMethod(createJUnitFixtureMethod(spec, method, MethodKind.SETUP, BeforeEach.class));
+                spec.getSetupMethods().add(0, createJUnitFixtureMethod(spec, method, MethodKind.SETUP, BeforeEach.class));
+            }
+            if (method.isAnnotationPresent(AfterEach.class)) {
+                spec.addCleanupMethod(createJUnitFixtureMethod(spec, method, MethodKind.CLEANUP, AfterEach.class));
+            }
+            if (method.isAnnotationPresent(BeforeAll.class)) {
+                spec.getSetupSpecMethods().add(0, createJUnitFixtureMethod(spec, method, MethodKind.SETUP_SPEC, BeforeAll.class));
+            }
+            if (method.isAnnotationPresent(AfterAll.class)) {
+                spec.addCleanupSpecMethod(createJUnitFixtureMethod(spec, method, MethodKind.CLEANUP_SPEC, AfterAll.class));
             }
         }
     }

--- a/grails-testing-support/src/main/groovy/org/grails/testing/spock/TestingSupportExtension.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/spock/TestingSupportExtension.groovy
@@ -1,15 +1,13 @@
 package org.grails.testing.spock
 
-import grails.testing.spock.OnceBefore
 import grails.testing.spring.AutowiredTest
 import groovy.transform.CompileStatic
 import org.grails.testing.GrailsUnitTest
-import org.junit.After
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
-import org.spockframework.runtime.extension.AbstractGlobalExtension
+import org.spockframework.runtime.extension.IGlobalExtension
 import org.spockframework.runtime.model.MethodInfo
 import org.spockframework.runtime.model.MethodKind
 import org.spockframework.runtime.model.SpecInfo
@@ -19,7 +17,7 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
 @CompileStatic
-class TestingSupportExtension extends AbstractGlobalExtension {
+class TestingSupportExtension implements IGlobalExtension {
 
     AutowiredInterceptor autowiredInterceptor = new AutowiredInterceptor()
     CleanupContextInterceptor cleanupContextInterceptor = new CleanupContextInterceptor()
@@ -32,48 +30,49 @@ class TestingSupportExtension extends AbstractGlobalExtension {
         if (GrailsUnitTest.isAssignableFrom(spec.reflection)) {
             spec.addCleanupSpecInterceptor(cleanupContextInterceptor)
         }
-        for (Method method : spec.getReflection().getDeclaredMethods()) {
+        for (Method method : (spec.getReflection().declaredMethods)) {
             if (method.isAnnotationPresent(BeforeEach.class)) {
-                spec.getSetupMethods().add(0, createJUnitFixtureMethod(spec, method, MethodKind.SETUP, BeforeEach.class));
+                spec.setupMethods.add(0, createJUnitFixtureMethod(spec, method, MethodKind.SETUP, BeforeEach.class))
             }
             if (method.isAnnotationPresent(AfterEach.class)) {
-                spec.addCleanupMethod(createJUnitFixtureMethod(spec, method, MethodKind.CLEANUP, AfterEach.class));
+                spec.addCleanupMethod(createJUnitFixtureMethod(spec, method, MethodKind.CLEANUP, AfterEach.class))
             }
             if (method.isAnnotationPresent(BeforeAll.class)) {
-                spec.getSetupSpecMethods().add(0, createJUnitFixtureMethod(spec, method, MethodKind.SETUP_SPEC, BeforeAll.class));
+                spec.setupSpecMethods.add(0, createJUnitFixtureMethod(spec, method, MethodKind.SETUP_SPEC, BeforeAll.class))
             }
             if (method.isAnnotationPresent(AfterAll.class)) {
-                spec.addCleanupSpecMethod(createJUnitFixtureMethod(spec, method, MethodKind.CLEANUP_SPEC, AfterAll.class));
+                spec.addCleanupSpecMethod(createJUnitFixtureMethod(spec, method, MethodKind.CLEANUP_SPEC, AfterAll.class))
             }
         }
     }
 
-    private MethodInfo createMethod(SpecInfo specInfo, Method method, MethodKind kind, String name) {
-        MethodInfo methodInfo = new MethodInfo();
-        methodInfo.setParent(specInfo);
-        methodInfo.setName(name);
-        methodInfo.setReflection(method);
-        methodInfo.setKind(kind);
-        return methodInfo;
+    private static MethodInfo createMethod(SpecInfo specInfo, Method method, MethodKind kind, String name) {
+        MethodInfo methodInfo = new MethodInfo()
+        methodInfo.parent = specInfo
+        methodInfo.name = name
+        methodInfo.reflection = method
+        methodInfo.kind = kind
+        return methodInfo
     }
 
-    private MethodInfo createJUnitFixtureMethod(SpecInfo specInfo, Method method, MethodKind kind, Class<? extends Annotation> annotation) {
-        MethodInfo methodInfo = createMethod(specInfo, method, kind, method.getName());
-        methodInfo.setExcluded(isOverriddenJUnitFixtureMethod(specInfo, method, annotation));
-        return methodInfo;
+    private static MethodInfo createJUnitFixtureMethod(SpecInfo specInfo, Method method, MethodKind kind, Class<? extends Annotation> annotation) {
+        MethodInfo methodInfo = createMethod(specInfo, method, kind, method.name)
+        methodInfo.excluded = isOverriddenJUnitFixtureMethod(specInfo, method, annotation)
+        return methodInfo
     }
-    private boolean isOverriddenJUnitFixtureMethod(SpecInfo specInfo, Method method, Class<? extends Annotation> annotation) {
-        if (Modifier.isPrivate(method.getModifiers())) return false;
 
-        for (Class<?> currClass = specInfo.class; currClass != specInfo.class.superclass; currClass = currClass.getSuperclass()) {
-            for (Method currMethod : currClass.getDeclaredMethods()) {
-                if (!currMethod.isAnnotationPresent(annotation)) continue;
-                if (!currMethod.getName().equals(method.getName())) continue;
-                if (!Arrays.deepEquals(currMethod.getParameterTypes(), method.getParameterTypes())) continue;
-                return true;
+    private static boolean isOverriddenJUnitFixtureMethod(SpecInfo specInfo, Method method, Class<? extends Annotation> annotation) {
+        if (Modifier.isPrivate(method.modifiers)) return false
+
+        for (Class<?> currClass = specInfo.class; currClass != specInfo.class.superclass; currClass = currClass.superclass) {
+            for (Method currMethod : currClass.declaredMethods) {
+                if (!currMethod.isAnnotationPresent(annotation)) continue
+                if (currMethod.name != method.name) continue
+                if (!Arrays.deepEquals(currMethod.parameterTypes, method.parameterTypes)) continue
+                return true
             }
         }
 
-        return false;
+        return false
     }
 }

--- a/grails-testing-support/src/test/groovy/grails/testing/spock/JUnitAnnotationSpec.groovy
+++ b/grails-testing-support/src/test/groovy/grails/testing/spock/JUnitAnnotationSpec.groovy
@@ -1,0 +1,57 @@
+package grails.testing.spock
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@Stepwise
+class JUnitAnnotationSpec extends Specification {
+    @Shared
+    static List<String> methodOrder = []
+
+    void setupSpec() {
+        methodOrder << "setupSpec"
+    }
+
+    void setup() {
+        methodOrder << "setup"
+    }
+
+    void cleanup() {
+        methodOrder << "cleanup"
+    }
+
+    void cleanupSpec() {
+        methodOrder << "cleanupSpec"
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        methodOrder << "beforeEach"
+    }
+
+    @AfterEach
+    void afterEach() {
+        methodOrder << "afterEach"
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        methodOrder << "beforeAll"
+    }
+
+    @AfterAll
+    static void afterAll() {
+        methodOrder << "afterAll"
+        assert methodOrder == ["beforeAll", "setupSpec", "beforeEach", "setup", "cleanup", "afterEach", "cleanupSpec", "afterAll"]
+    }
+
+    void 'junit 5 annotated methods are called in correct order prior to this test'() {
+        expect:
+        methodOrder == ["beforeAll", "setupSpec", "beforeEach", "setup"]
+    }
+}

--- a/grails-testing-support/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy
+++ b/grails-testing-support/src/test/groovy/grails/testing/spock/OnceBeforeSpec.groovy
@@ -1,6 +1,5 @@
 package grails.testing.spock
 
-import org.junit.Before
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Stepwise


### PR DESCRIPTION
https://github.com/grails/grails-testing-support/pull/158 was originally merged, but merged incorrectly into the wrong branch that was never merged back to the next major release branch. This PR merges that change into 4.0.x.