### PR TITLE
Reapply "catch exception in GrailsApplicationBuilder (#425)"

### DIFF
--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
@@ -124,13 +124,11 @@ class GrailsApplicationBuilder {
         def beanFactory = context.getBeanFactory()
         def beanExcludes = [ConversionService, Environment, PropertyResolver, ConfigurableEnvironment]
 
-        Class<?> objectMapper
         try {
-            objectMapper = ClassUtils.forName('com.fasterxml.jackson.databind.ObjectMapper', context.getClassLoader())
-        } catch (ignored) {
-        }
-        if (objectMapper) {
+            Class<?> objectMapper = ClassUtils.forName('com.fasterxml.jackson.databind.ObjectMapper', context.classLoader)
             beanExcludes.add(objectMapper)
+        } catch (ignored) {
+            // ObjectMapper not found on classpath
         }
 
         (beanFactory as DefaultListableBeanFactory).with {

--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
@@ -123,10 +123,16 @@ class GrailsApplicationBuilder {
         def configuredEnvironment = context.getEnvironment()
         def beanFactory = context.getBeanFactory()
         def beanExcludes = [ConversionService, Environment, PropertyResolver, ConfigurableEnvironment]
-        def objectMapper = ClassUtils.forName('com.fasterxml.jackson.databind.ObjectMapper', context.getClassLoader())
+
+        Class<?> objectMapper
+        try {
+            objectMapper = ClassUtils.forName('com.fasterxml.jackson.databind.ObjectMapper', context.getClassLoader())
+        } catch (ignored) {
+        }
         if (objectMapper) {
             beanExcludes.add(objectMapper)
         }
+
         (beanFactory as DefaultListableBeanFactory).with {
             setAllowBeanDefinitionOverriding(true)
             setAllowCircularReferences(true)


### PR DESCRIPTION
This reverts commit a793484c06e81c4937bed95cd804660a6e6f942b.

We will need a catch this exception given that Spring's ClassUtils.forName('com.fasterxml.jackson.databind.ObjectMapper', context.getClassLoader()) can throw an exception and https://docs.micronaut.io/4.6.5/api/io/micronaut/core/reflect/ClassUtils.html#forName(java.lang.String,java.lang.ClassLoader) did not.