### PR TITLE
Ensure messageSource type is StaticMessageSource for tests

### DIFF
--- a/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
+++ b/grails-testing-support/src/main/groovy/org/grails/testing/GrailsApplicationBuilder.groovy
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.support.RootBeanDefinition
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer
 import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebApplicationContext
 import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.MessageSource
 import org.springframework.context.annotation.AnnotationConfigRegistry
 import org.springframework.context.annotation.AnnotationConfigUtils
 import org.springframework.context.support.ConversionServiceFactoryBean
@@ -91,6 +92,11 @@ class GrailsApplicationBuilder {
         if (!grailsApplication.isInitialised()) {
             grailsApplication.initialise()
         }
+
+        // I18nGrailsPlugin sets messageSource to type PluginAwareResourceBundleMessageSource in doWithSpring()
+        // tests expect type StaticMessageSource which includes addMessage() methods
+        def beanFactory = mainContext.getBeanFactory()
+        (beanFactory as BeanDefinitionRegistry).registerBeanDefinition("messageSource", new RootBeanDefinition(StaticMessageSource.class))
 
         return this
     }


### PR DESCRIPTION
`StaticMessageSource` incudes `addMessage()` methods, required by tests

after removing micronaut, the `messageSource` type was `PluginAwareResourceBundleMessageSource` instead of `StaticMessageSource` when the tests execute

`org.grails.plugins.i18n.I18nGrailsPlugin doWithSpring()` sets `messageSource` to type `PluginAwareResourceBundleMessageSource`

`org.grails.testing.GrailsApplicationBuilder.build()` sets `messageSource` to type `StaticMessageSource` in `doWithSpringClosure{}` which calls `registerBeans()`

On https://github.com/grails/grails-core/pull/13702

This fixes 22 tests that require StaticMessageSource 

It also fixes 6 tests in `DataBindingConfigurationSpec` with `ValueConverters` using `@Order`