### PR TITLE
grails-testing-support: re-enable views-json plugin and add dependsOn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ subprojects { project ->
     apply plugin: "groovy"
     if (project.name.startsWith("examples")) {
         apply plugin: "org.grails.grails-web"
-        //apply plugin: "org.grails.plugins.views-json"
+        apply plugin: "org.grails.plugins.views-json"
     } else {
         apply plugin: "java-library"
         if (isGrailsPlugin) {

--- a/examples/demo33/build.gradle
+++ b/examples/demo33/build.gradle
@@ -92,6 +92,4 @@ tasks.withType(Jar).configureEach {
     duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
-
-
-
+compileTestGroovy.dependsOn(compileGsonViews)


### PR DESCRIPTION
`compileTestGroovy.dependsOn(compileGsonViews)` added to resolve

```
Reason: Task ':examples-demo33:compileTestGroovy' uses this output of task ':examples-demo33:compileGsonViews' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':examples-demo33:compileGsonViews' as an input of ':examples-demo33:compileTestGroovy'.
      2. Declare an explicit dependency on ':examples-demo33:compileGsonViews' from ':examples-demo33:compileTestGroovy' using Task#dependsOn.
      3. Declare an explicit dependency on ':examples-demo33:compileGsonViews' from ':examples-demo33:compileTestGroovy' using Task#mustRunAfter.
```
    