### PR TITLE
Update to asset pipeline 5.0.4 by using version from grails-bom

### DIFF
--- a/examples/demo33/build.gradle
+++ b/examples/demo33/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     profile "org.grails.profiles:web"
     runtimeOnly "com.h2database:h2"
     runtimeOnly "org.apache.tomcat:tomcat-jdbc"
-    runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails:$assetPipelineVersion"
+    runtimeOnly "com.bertramlabs.plugins:asset-pipeline-grails"
 
     testImplementation project(':grails-web-testing-support')
     testImplementation project(':grails-gorm-testing-support')

--- a/examples/demo33/src/integration-test/groovy/demo/JsonControllerSpec.groovy
+++ b/examples/demo33/src/integration-test/groovy/demo/JsonControllerSpec.groovy
@@ -32,6 +32,6 @@ class JsonControllerSpec extends Specification {
         def response = new URL("http://localhost:$serverPort/json/index").getText()
 
         then:
-        response == '\n<html><head><title></title></head><body>Testing</body></html>'
+        response.contains('<html><head><title></title></head><body>Testing</body></html>')
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,6 @@ developers=Jeff Brown,James Kleeh
 
 #4.0.2-4.0.3 breaks org.ysb33r.gradle:grolifant for chromedriver due to switching to org.ysb33r.gradle:grolifant-rawhide:3.0.0
 asciidoctorJvmVersion=4.0.1
-assetPipelineVersion=5.0.1
 bytebuddyVersion=1.15.3
 grailsGradlePluginVersion=7.0.0-SNAPSHOT
 grailsVersion=7.0.0-SNAPSHOT


### PR DESCRIPTION
Makes JsonControllerSpec test cross platform compatible in 2nd commit.